### PR TITLE
docs: 校准 0.4.2 实际 Zotero 验收版本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 已知界面现象：原生截图验收中曾出现窄窗口导航未自动收起，同包复跑恢复正常，根因尚未确认；遇到时可使用侧栏收起按钮。
 
-Manifest 声明 Zotero **8.0–10.0.***；本版原生验收使用 **Windows 11 / Zotero 10.0.1**、隔离 profile、合成资料与模拟服务。其他系统、Zotero 8/9、真实 Provider 翻译品质及实际 Crossref 命中率未实测。最终安装包校验和原生验收结果见 [v0.4.2 Release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2)。
+Manifest 声明 Zotero **8.0–10.0.***；本版原生验收使用 **Windows 11 / Zotero 10.0.2**、隔离 profile、合成资料与模拟服务。其他系统、Zotero 8/9、真实 Provider 翻译品质及实际 Crossref 命中率未实测。最终安装包校验和原生验收结果见 [v0.4.2 Release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2)。
 
 <a id="release-042-en"></a>
 
@@ -46,7 +46,7 @@ Full translation requires extractable PDF text, provides no OCR or original-layo
 
 Known UI behavior: a native screenshot run intermittently failed to collapse navigation in a narrow window; the same package passed on rerun, and the cause remains unconfirmed. Use the sidebar collapse button if needed.
 
-The manifest declares Zotero **8.0–10.0.***. Native validation uses **Windows 11 / Zotero 10.0.1**, isolated profiles, synthetic documents, and mocked services. Other platforms, Zotero 8/9, real-provider translation quality, and real Crossref matching accuracy were not tested. See the [v0.4.2 release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2) for final artifact checksums and validation results.
+The manifest declares Zotero **8.0–10.0.***. Native validation uses **Windows 11 / Zotero 10.0.2**, isolated profiles, synthetic documents, and mocked services. Other platforms, Zotero 8/9, real-provider translation quality, and real Crossref matching accuracy were not tested. See the [v0.4.2 release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2) for final artifact checksums and validation results.
 
 ## 0.4.1 — 2026-09-09
 

--- a/README.en.md
+++ b/README.en.md
@@ -144,7 +144,7 @@ Local history does not mean offline AI. Extractable text from an attached PDF ca
 
 ### Which versions are supported? What are the reading limits?
 
-The manifest declares compatibility with **Zotero 8.0 through 10.0.***. Release 0.4.2 was tested on **Windows 11 / Zotero 10.0.1**, using synthetic materials and mocked services. macOS, Linux, Zotero 8/9, and real paid providers were not tested in that release validation. See the [release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2) for the full validation record and scope.
+The manifest declares compatibility with **Zotero 8.0 through 10.0.***. Release 0.4.2 was tested on **Windows 11 / Zotero 10.0.2**, using synthetic materials and mocked services. macOS, Linux, Zotero 8/9, and real paid providers were not tested in that release validation. See the [release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2) for the full validation record and scope.
 
 Scanned PDFs need OCR before operations that depend on extracted text. Analysis depends on the extractable text and model output; check the results against the paper. If generation is interrupted or some annotations cannot be saved, the plugin attempts to retain the generated notes and reports the outcome. Each message can include one new image. Images that were not saved by older versions cannot be recovered automatically.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Jadense in Zotero 是[攻玉学术（Jadense）](https://jadense.cn/)推出的�
 
 ### 支持哪些版本？有哪些阅读限制？
 
-Manifest 声明兼容 Zotero **8.0 至 10.0.***；0.4.2 的实际验收环境是 **Windows 11 / Zotero 10.0.1**，使用合成资料与模拟接口。macOS、Linux、Zotero 8/9 及真实付费 Provider 未在该次发布中实测，完整验收记录与范围见 [Release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2)。
+Manifest 声明兼容 Zotero **8.0 至 10.0.***；0.4.2 的实际验收环境是 **Windows 11 / Zotero 10.0.2**，使用合成资料与模拟接口。macOS、Linux、Zotero 8/9 及真实付费 Provider 未在该次发布中实测，完整验收记录与范围见 [Release](https://github.com/jadense-ai/jadense-in-zotero/releases/tag/v0.4.2)。
 
 扫描 PDF 需先 OCR 才能进行依赖正文提取的操作。解析结果受文本可提取范围和模型输出影响，请结合原文核对；中断或部分批注写入失败时会尽可能保留已生成笔记并提示结果。每条消息可新附一张图片，旧版本未保存的图片无法自动恢复。
 


### PR DESCRIPTION
核对本机 Zotero 可执行文件后确认本次 0.4.2 原生验收实际运行于 Zotero 10.0.2 / Windows 11，而历史 0.4.1 验收使用 10.0.1。修正中英文 README 与 0.4.2 更新说明的实测环境，保留历史版本记录及功能最低版本要求。

仅文档修正，v0.4.2 标签及 CI 原始 XPI 不变。文件版本读取、历史记录边界及 git diff --check 已核对；本次验证将继续直接使用同一标签 XPI。
